### PR TITLE
Allow to use Quill for SQL queries

### DIFF
--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/models/schema.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/models/schema.scala
@@ -1,0 +1,38 @@
+package org.ergoplatform.explorer.db.models
+
+import io.getquill.{idiom => _, _}
+
+object schema {
+
+  import doobie.quill.DoobieContext
+
+  val ctx = new DoobieContext.Postgres(Literal) // Literal naming scheme
+  import ctx._
+
+  val Assets = quote {
+    querySchema[Asset](
+      "node_assets",
+      _.tokenId  -> "token_id",
+      _.boxId    -> "box_id",
+      _.headerId -> "header_id",
+      _.amount   -> "value"
+    )
+  }
+
+  val Outputs = quote {
+    querySchema[Output](
+      "node_outputs",
+      _.boxId               -> "box_id",
+      _.txId                -> "tx_id",
+      _.value               -> "value",
+      _.creationHeight      -> "creation_height",
+      _.index               -> "index",
+      _.ergoTree            -> "ergo_tree",
+      _.addressOpt          -> "address",
+      _.additionalRegisters -> "additional_registers",
+      _.timestamp           -> "timestamp",
+      _.mainChain           -> "main_chain"
+    )
+  }
+
+}

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/AssetQuerySet.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/AssetQuerySet.scala
@@ -14,6 +14,8 @@ import org.ergoplatform.explorer.db.models.Asset
 object AssetQuerySet extends QuerySet {
 
   import org.ergoplatform.explorer.db.doobieInstances._
+  import org.ergoplatform.explorer.db.models.schema
+  import org.ergoplatform.explorer.db.models.schema.ctx._
 
   val tableName: String = "node_assets"
 
@@ -24,12 +26,15 @@ object AssetQuerySet extends QuerySet {
     "value"
   )
 
-  def getAllByBoxId(boxId: BoxId): Query0[Asset] =
-    sql"select * from node_assets where box_id = $boxId".query[Asset]
+  def getAllByBoxId(boxId: BoxId) =
+    quote {
+      schema.Assets.filter(_.boxId == lift(boxId))
+    }
 
-  def getAllByBoxIds(boxIds: NonEmptyList[BoxId]): Query0[Asset] =
-    (sql"select * from node_assets" ++ Fragments.in(fr"where box_id", boxIds))
-      .query[Asset]
+  def getAllByBoxIds(boxIds: NonEmptyList[BoxId]) =
+    quote {
+      schema.Assets.filter(a => liftQuery(boxIds.toList).contains(a.boxId))
+    }
 
   def getAllHoldingAddresses(
     tokenId: TokenId,

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/AssetRepo.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/AssetRepo.scala
@@ -8,6 +8,7 @@ import org.ergoplatform.explorer.db.algebra.LiftConnectionIO
 import org.ergoplatform.explorer.db.syntax.liftConnectionIO._
 import org.ergoplatform.explorer.db.models.Asset
 import org.ergoplatform.explorer.db.models.aggregates.ExtendedOutput
+import org.ergoplatform.explorer.db.models.schema.ctx._
 import org.ergoplatform.explorer.{Address, BoxId, TokenId}
 
 /** [[Asset]] data access operations.
@@ -65,10 +66,10 @@ object AssetRepo {
       QS.insertMany(assets).void.liftConnectionIO
 
     def getAllByBoxId(boxId: BoxId): D[List[Asset]] =
-      QS.getAllByBoxId(boxId).to[List].liftConnectionIO
+      run(QS.getAllByBoxId(boxId)).liftConnectionIO
 
     def getAllByBoxIds(boxIds: NonEmptyList[BoxId]): D[List[Asset]] =
-      QS.getAllByBoxIds(boxIds).to[List].liftConnectionIO
+      run(QS.getAllByBoxIds(boxIds)).liftConnectionIO
 
     def getAllHoldingAddresses(
       tokenId: TokenId,

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/package.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/package.scala
@@ -12,6 +12,7 @@ import eu.timepit.refined.string.{HexStringSpec, MatchesRegex, Url}
 import io.circe.refined._
 import io.circe.{Decoder, Encoder}
 import io.estatico.newtype.macros.newtype
+import io.getquill.{idiom => _, _}
 import org.ergoplatform.explorer.Err.{ProcessingErr, RefinementFailed}
 import org.ergoplatform.explorer.constraints._
 import sttp.tapir.json.circe._
@@ -39,6 +40,10 @@ package object explorer {
     // doobie instances
     implicit def get: Get[Id] = deriving
     implicit def put: Put[Id] = deriving
+
+    // quill instances
+    implicit val encodeId = MappedEncoding[Id, String](_.toString)
+    implicit val decodeId = MappedEncoding[String, Id](Id.apply(_))
 
     // circe instances
     implicit def encoder: Encoder[Id] = deriving
@@ -78,6 +83,10 @@ package object explorer {
     implicit def get: Get[BoxId] = deriving
     implicit def put: Put[BoxId] = deriving
 
+    // quill instances
+    implicit val encodeBoxId = MappedEncoding[BoxId, String](_.toString)
+    implicit val decodeBoxId = MappedEncoding[String, BoxId](BoxId.apply(_))
+
     // circe instances
     implicit def encoder: Encoder[BoxId] = deriving
     implicit def decoder: Decoder[BoxId] = deriving
@@ -96,6 +105,10 @@ package object explorer {
     // doobie instances
     implicit def get: Get[TokenId] = deriving
     implicit def put: Put[TokenId] = deriving
+
+    // quill instances
+    implicit val encodeTokenId = MappedEncoding[TokenId, String](_.toString)
+    implicit val decodeTokenId = MappedEncoding[String, TokenId](TokenId.apply(_))
 
     // circe instances
     implicit def encoder: Encoder[TokenId] = deriving

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -9,6 +9,7 @@ object dependencies {
   }
 
   object http4s extends DependencyGroup {
+
     override def deps: List[ModuleID] =
       List(
         "org.http4s" %% "http4s-dsl",
@@ -19,6 +20,7 @@ object dependencies {
   }
 
   object tapir extends DependencyGroup {
+
     override def deps: List[ModuleID] =
       List(
         "com.softwaremill.sttp.tapir" %% "tapir-core",
@@ -30,6 +32,7 @@ object dependencies {
   }
 
   object circe extends DependencyGroup {
+
     override def deps: List[ModuleID] =
       List(
         "io.circe" %% "circe-core",
@@ -42,6 +45,7 @@ object dependencies {
   }
 
   object cats extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "org.typelevel" %% "cats-core"           % CatsVersion,
       "org.typelevel" %% "cats-effect"         % CatsEffectVersion,
@@ -54,6 +58,7 @@ object dependencies {
   }
 
   object zio extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "dev.zio" %% "zio"              % ZioVersion,
       "dev.zio" %% "zio-interop-cats" % ZioCatsVersion
@@ -61,6 +66,7 @@ object dependencies {
   }
 
   object monocle extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "com.github.julien-truffaut" %% "monocle-core"  % MonocleVersion,
       "com.github.julien-truffaut" %% "monocle-macro" % MonocleVersion
@@ -68,24 +74,28 @@ object dependencies {
   }
 
   object fs2 extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "co.fs2" %% "fs2-core" % Fs2Version
     )
   }
 
   object tofu extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "ru.tinkoff" %% "tofu-core" % TofuVersion
     )
   }
 
   object ergo extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "org.ergoplatform" %% "ergo-wallet" % ErgoWalletVersion
     )
   }
 
   object logging extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "ch.qos.logback"    % "logback-classic" % Logback,
       "org.slf4j"         % "slf4j-api"       % Slf4j,
@@ -94,17 +104,20 @@ object dependencies {
   }
 
   object db extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "org.tpolecat" %% "doobie-core"      % DoobieVersion,
       "org.tpolecat" %% "doobie-postgres"  % DoobieVersion,
       "org.tpolecat" %% "doobie-scalatest" % DoobieVersion,
       "org.tpolecat" %% "doobie-hikari"    % DoobieVersion,
       "org.tpolecat" %% "doobie-refined"   % DoobieVersion,
+      "org.tpolecat" %% "doobie-quill"     % DoobieVersion,
       "org.flywaydb" % "flyway-core"       % FlywayVersion
     )
   }
 
   object testing extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "org.tpolecat"               %% "doobie-scalatest"          % DoobieVersion                 % Test,
       "org.scalatest"              %% "scalatest"                 % ScalaTestVersion              % Test,
@@ -116,6 +129,7 @@ object dependencies {
   }
 
   object newtypes extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "org.scalaz"  %% "deriving-macro" % DerivingVersion,
       "io.estatico" %% "newtype"        % NewtypeVersion,
@@ -125,6 +139,7 @@ object dependencies {
   }
 
   object config extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "com.github.pureconfig" %% "pureconfig"             % PureConfigVersion,
       "com.github.pureconfig" %% "pureconfig-cats-effect" % PureConfigVersion
@@ -132,6 +147,7 @@ object dependencies {
   }
 
   object simulacrum extends DependencyGroup {
+
     override def deps: List[ModuleID] = List(
       "com.github.mpilquist" %% "simulacrum" % SimulacrumVersion
     )


### PR DESCRIPTION
### Motivation
Writing SQL queries with doobie's SQL string interpolator has drawbacks:
- no type-safety;
- non-reusable, copy-pasted SQL queries (think joins on a few tables);

###  Implementation
Doobie offers Quill integration - https://tpolecat.github.io/doobie/docs/17-Quill.html
To use Quill we need to:
- define DB schema mapping for case classes [Asset](http://github.com/ergoplatform/explorer-backend/blob/ccf8a392bff58175190e24f0d11b82dc3d7a172e/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/models/schema.scala#L12-L21);
- Encoders/Decoders for custom types [TokenId](http://github.com/ergoplatform/explorer-backend/blob/ccf8a392bff58175190e24f0d11b82dc3d7a172e/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/package.scala#L109-L112)

Here is a couple of queries I've migrated to Quill in this PR:
From:
```
  def getAllByBoxId(boxId: BoxId): Query0[Asset] =
    sql"select * from node_assets where box_id = $boxId".query[Asset]

  def getAllByBoxIds(boxIds: NonEmptyList[BoxId]): Query0[Asset] =
    (sql"select * from node_assets" ++ Fragments.in(fr"where box_id", boxIds))
      .query[Asset]
```
To:
```
  def getAllByBoxId(boxId: BoxId) =
    quote {
      schema.Assets.filter(_.boxId == lift(boxId))
    }

  def getAllByBoxIds(boxIds: NonEmptyList[BoxId]) =
    quote {
      schema.Assets.filter(a => liftQuery(boxIds.toList).contains(a.boxId))
    }
```

I suggest we merge it, write new requests with Quill and gradually migrate existing requests to it.

### References
Quill - https://getquill.io