### PR TITLE
Recently confirmed transactions exlusion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 lazy val commonSettings = Seq(
   scalacOptions ++= commonScalacOptions,
-  scalaVersion := "2.12.10",
+  scalaVersion := "2.12.11",
   organization := "org.ergoplatform",
-  version := "0.0.1",
+  version := "1.0.0",
   resolvers += Resolver.sonatypeRepo("public"),
   resolvers += Resolver.sonatypeRepo("snapshots"),
   test in assembly := {},

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/HeaderQuerySet.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/HeaderQuerySet.scala
@@ -38,7 +38,7 @@ object HeaderQuerySet extends QuerySet {
     sql"select * from node_headers where id = $id".query[Header]
 
   def getLast(implicit lh: LogHandler): Query0[Header] =
-    sql"select * from node_headers order by height desc limit 1".query[Header]
+    sql"select * from node_headers where main_chain = true order by height desc limit 1".query[Header]
 
   def getByParentId(parentId: Id)(implicit lh: LogHandler): Query0[Header] =
     sql"select * from node_headers where parent_id = $parentId".query[Header]

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/TransactionQuerySet.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/TransactionQuerySet.scala
@@ -46,6 +46,14 @@ object TransactionQuerySet extends QuerySet {
          |order by t.index asc
          |""".stripMargin.query[Transaction]
 
+  def getRecentIds(implicit lh: LogHandler): Query0[TxId] =
+    sql"""
+         |select t.id from node_transactions
+         |inner join (
+         |  select h.id from node_headers h where main_chain = true order by height desc limit 1
+         |) as nh on nh.id = t.header_id
+         |""".stripMargin.query[TxId]
+
   def getAllRelatedToAddress(
     address: Address,
     offset: Int,

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/TransactionQuerySet.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/TransactionQuerySet.scala
@@ -48,10 +48,10 @@ object TransactionQuerySet extends QuerySet {
 
   def getRecentIds(implicit lh: LogHandler): Query0[TxId] =
     sql"""
-         |select t.id from node_transactions
+         |select t.id from node_transactions t
          |inner join (
-         |  select h.id from node_headers h where main_chain = true order by height desc limit 1
-         |) as nh on nh.id = t.header_id
+         |  select h.id from node_headers h where h.main_chain = true order by h.height desc limit 1
+         |) as h on h.id = t.header_id
          |""".stripMargin.query[TxId]
 
   def getAllRelatedToAddress(

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/UTransactionQuerySet.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/UTransactionQuerySet.scala
@@ -41,7 +41,7 @@ object UTransactionQuerySet extends QuerySet {
          |""".stripMargin.query[UTransaction]
 
   def getAll(offset: Int, limit: Int)(implicit lh: LogHandler): Query0[UTransaction] =
-    sql"select * from node_u_transactions offset $offset limit $limit".query[UTransaction]
+    sql"select * from node_u_transactions order by creation_timestamp desc offset $offset limit $limit".query[UTransaction]
 
   def getAllIds(implicit lh: LogHandler): Query0[TxId] =
     sql"select id from node_u_transactions".query[TxId]

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/TransactionRepo.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/TransactionRepo.scala
@@ -35,6 +35,10 @@ trait TransactionRepo[D[_], S[_[_], _]] {
     */
   def getAllByBlockId(id: Id): S[D, Transaction]
 
+  /** Get transaction ids from latest block from main-chain.
+    */
+  def getRecentIds: D[List[TxId]]
+
   /** Get transactions related to a given `address`.
     */
   def getRelatedToAddress(
@@ -96,6 +100,9 @@ object TransactionRepo {
 
     def getAllByBlockId(id: Id): Stream[D, Transaction] =
       QS.getAllByBlockId(id).stream.translate(liftK)
+
+    def getRecentIds: D[List[TxId]] =
+      QS.getRecentIds.to[List].liftConnectionIO
 
     def getRelatedToAddress(
       address: Address,


### PR DESCRIPTION
Recently confirmed transactions are now excluded from `transactions/unconfirmed` and `transactions/unconfirmed/byAddress` routes.