### PR TITLE
Fix: Correct additionalRegisters field type in API documentation (#258)

### DIFF
--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/AnyOutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/AnyOutputInfo.scala
@@ -51,9 +51,29 @@ object AnyOutputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 
   def apply(
     o: AnyOutput,

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/DataInputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/DataInputInfo.scala
@@ -41,9 +41,29 @@ object DataInputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 
   def apply(i: FullDataInput, assets: List[ExtendedAsset]): DataInputInfo =
     DataInputInfo(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/InputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/InputInfo.scala
@@ -51,9 +51,29 @@ object InputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 
   def apply(i: FullInput, assets: List[ExtendedAsset]): InputInfo = {
     val (ergoTreeConstants, ergoTreeScript) = PrettyErgoTree.fromHexString(i.ergoTree).fold(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/MOutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/MOutputInfo.scala
@@ -88,7 +88,27 @@ object MOutputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 }

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/OutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/OutputInfo.scala
@@ -51,9 +51,29 @@ object OutputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 
   def apply(
     o: ExtendedOutput,

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UDataInputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UDataInputInfo.scala
@@ -41,9 +41,29 @@ object UDataInputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 
   def apply(i: ExtendedUDataInput, assets: List[ExtendedUAsset]): UDataInputInfo =
     UDataInputInfo(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UInputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UInputInfo.scala
@@ -43,9 +43,29 @@ object UInputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 
   def apply(i: ExtendedUInput, assets: List[ExtendedUAsset], confirmedAssets: List[ExtendedAsset]): UInputInfo =
     UInputInfo(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UOutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UOutputInfo.scala
@@ -42,9 +42,29 @@ object UOutputInfo {
   implicit private def registersSchema: Schema[Json] =
     Schema(
       SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
+        Schema(
+          SchemaType.SProduct(
+            List(
+              SchemaType.SProductField[Json, String](
+                sttp.tapir.FieldName("serializedValue"),
+                Schema(SchemaType.SString[Json]()).description("Hex-encoded serialized register value"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("sigmaType"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Sigma type of the register"),
+                j => None
+              ),
+              SchemaType.SProductField[Json, Option[String]](
+                sttp.tapir.FieldName("renderedValue"),
+                Schema(SchemaType.SOption(Schema(SchemaType.SString[Json]()))()).description("Human-readable rendered value"),
+                j => None
+              )
+            )
+          )
+        )
       )(_ => Map.empty)
-    )
+    ).description("Additional registers stored in the box as a map from register ID to register value object")
 
   def apply(
     o: ExtendedUOutput,


### PR DESCRIPTION
This PR resolves issue #258 by fixing the type inconsistency in the API documentation for the additionalRegisters field. Previously, the field was documented as a simple string for each key, but the actual API returns an object containing serializedValue, sigmaType, and renderedValue.

Changes Made:

Updated the schema definitions in the affected V1 API model files to correctly represent the ExpandedRegister structure.
The additionalRegisters field is now documented as a Map[RegisterId, ExpandedRegister], where ExpandedRegister includes:
serializedValue (string): Hex-encoded serialized register value.
sigmaType (optional string): Sigma type of the register.
renderedValue (optional string): Human-readable rendered value.
Files Modified:

OutputInfo.scala
InputInfo.scala
UOutputInfo.scala
UInputInfo.scala
DataInputInfo.scala
UDataInputInfo.scala
AnyOutputInfo.scala
MOutputInfo.scala
Impact:

OpenAPI documentation now accurately reflects the API response structure.
Autogenerated API clients will have proper types for additionalRegisters.
No breaking changes to the actual API responses.
Testing:

