### PR TITLE
Fix global ordering and wire sortDirection in boxes byAddress/byErgoT…

### DIFF
--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/defs/BoxesEndpointDefs.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/defs/BoxesEndpointDefs.scala
@@ -104,10 +104,11 @@ final class BoxesEndpointDefs[F[_]](settings: RequestsSettings) {
       .in(PathPrefix / path[BoxId])
       .out(jsonBody[OutputInfo])
 
-  def getOutputsByErgoTreeDef: Endpoint[(HexString, Paging), ApiErr, Items[OutputInfo], Any] =
+  def getOutputsByErgoTreeDef: Endpoint[(HexString, Paging, SortOrder), ApiErr, Items[OutputInfo], Any] =
     baseEndpointDef.get
       .in(PathPrefix / "byErgoTree" / path[HexString])
       .in(paging(settings.maxEntitiesPerRequest))
+      .in(ordering)
       .out(jsonBody[Items[OutputInfo]])
 
   def getUnspentOutputsByErgoTreeDef: Endpoint[(HexString, Paging, SortOrder), ApiErr, Items[OutputInfo], Any] =
@@ -130,10 +131,11 @@ final class BoxesEndpointDefs[F[_]](settings: RequestsSettings) {
       .in(paging(settings.maxEntitiesPerRequest))
       .out(jsonBody[Items[OutputInfo]])
 
-  def getOutputsByAddressDef: Endpoint[(Address, Paging), ApiErr, Items[OutputInfo], Any] =
+  def getOutputsByAddressDef: Endpoint[(Address, Paging, SortOrder), ApiErr, Items[OutputInfo], Any] =
     baseEndpointDef.get
       .in(PathPrefix / "byAddress" / path[Address])
       .in(paging(settings.maxEntitiesPerRequest))
+      .in(ordering)
       .out(jsonBody[Items[OutputInfo]])
 
   def `getUnspent&UnconfirmedOutputsMergedByAddressDef`

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/routes/BoxesRoutes.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/routes/BoxesRoutes.scala
@@ -97,8 +97,8 @@ final class BoxesRoutes[
     }
 
   private def getOutputsByErgoTreeR: HttpRoutes[F] =
-    interpreter.toRoutes(defs.getOutputsByErgoTreeDef) { case (tree, paging) =>
-      service.getOutputsByErgoTree(tree, paging).adaptThrowable.value
+    interpreter.toRoutes(defs.getOutputsByErgoTreeDef) { case (tree, paging, ord) =>
+      service.getOutputsByErgoTree(tree, paging, ord).adaptThrowable.value
     }
 
   private def getUnspentOutputsByErgoTreeR: HttpRoutes[F] =
@@ -117,8 +117,8 @@ final class BoxesRoutes[
     }
 
   private def getOutputsByAddressR: HttpRoutes[F] =
-    interpreter.toRoutes(defs.getOutputsByAddressDef) { case (address, paging) =>
-      service.getOutputsByAddress(address, paging).adaptThrowable.value
+    interpreter.toRoutes(defs.getOutputsByAddressDef) { case (address, paging, ord) =>
+      service.getOutputsByAddress(address, paging, ord).adaptThrowable.value
     }
 
   private def getUnspentOutputsByAddressR: HttpRoutes[F] =

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/services/Boxes.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/services/Boxes.scala
@@ -50,7 +50,7 @@ trait Boxes[F[_]] {
 
   /** Get all outputs with the given `address` in proposition.
     */
-  def getOutputsByAddress(address: Address, paging: Paging): F[Items[OutputInfo]]
+  def getOutputsByAddress(address: Address, paging: Paging, ord: SortOrder): F[Items[OutputInfo]]
 
   def `getUnspent&UnconfirmedOutputsMergedByAddress`(
     address: Address,
@@ -63,7 +63,7 @@ trait Boxes[F[_]] {
 
   /** Get all outputs with the given `ergoTree` in proposition.
     */
-  def getOutputsByErgoTree(ergoTree: HexString, paging: Paging): F[Items[OutputInfo]]
+  def getOutputsByErgoTree(ergoTree: HexString, paging: Paging, ord: SortOrder): F[Items[OutputInfo]]
 
   /** Get unspent outputs with the given `ergoTree` in proposition.
     */
@@ -162,13 +162,13 @@ object Boxes {
         assets <- OptionT.liftF(assets.getAllByBoxId(box.output.boxId))
       } yield OutputInfo(box, assets)).value.thrushK(trans.xa)
 
-    def getOutputsByAddress(address: Address, paging: Paging): F[Items[OutputInfo]] = {
+    def getOutputsByAddress(address: Address, paging: Paging, ord: SortOrder): F[Items[OutputInfo]] = {
       val ergoTree = addressToErgoTreeHex(address)
       outputs
         .countAllByErgoTree(ergoTree)
         .flatMap { total =>
           outputs
-            .streamAllByErgoTree(ergoTree, paging.offset, paging.limit)
+            .streamAllByErgoTree(ergoTree, paging.offset, paging.limit, ord.value)
             .chunkN(serviceSettings.chunkSize)
             .through(toOutputInfo)
             .to[List]
@@ -223,12 +223,12 @@ object Boxes {
         .thrushK(trans.xa)
     }
 
-    def getOutputsByErgoTree(ergoTree: HexString, paging: Paging): F[Items[OutputInfo]] =
+    def getOutputsByErgoTree(ergoTree: HexString, paging: Paging, ord: SortOrder): F[Items[OutputInfo]] =
       outputs
         .countAllByErgoTree(ergoTree)
         .flatMap { total =>
           outputs
-            .streamAllByErgoTree(ergoTree, paging.offset, paging.limit)
+            .streamAllByErgoTree(ergoTree, paging.offset, paging.limit, ord.value)
             .chunkN(serviceSettings.chunkSize)
             .through(toOutputInfo)
             .to[List]

--- a/modules/explorer-api/src/test/scala/org/ergoplatform/explorer/v1/services/BoxSpec.scala
+++ b/modules/explorer-api/src/test/scala/org/ergoplatform/explorer/v1/services/BoxSpec.scala
@@ -14,7 +14,7 @@ import org.ergoplatform.explorer.cache.Redis
 import org.ergoplatform.explorer.commonGenerators.forSingleInstance
 import org.ergoplatform.explorer.db.algebra.LiftConnectionIO
 import org.ergoplatform.explorer.db.{repositories, RealDbTest, Trans}
-import org.ergoplatform.explorer.http.api.models.Paging
+import org.ergoplatform.explorer.http.api.models.{Paging, Sorting}
 import org.ergoplatform.explorer.http.api.models.Sorting.Desc
 import org.ergoplatform.explorer.testSyntax.runConnectionIO._
 import org.ergoplatform.explorer.http.api.streaming.CompileStream
@@ -81,7 +81,7 @@ class BS_A extends BoxSpec {
                     outRepo.insert(out).runWithIO()
                     txRepo.insert(tx).runWithIO()
                   }
-                  box.getOutputsByAddress(address1T.get, Paging(0, Int.MaxValue)).unsafeRunSync().total should be(3)
+                  box.getOutputsByAddress(address1T.get, Paging(0, Int.MaxValue), Sorting.Asc).unsafeRunSync().total should be(3)
                   (box invokePrivate getUnspentOutputsByAddressD(
                     address1T.get,
                     Desc,
@@ -139,7 +139,7 @@ class BS_B extends BoxSpec {
                     outRepo.insert(out).runWithIO()
                     txRepo.insert(tx).runWithIO()
                   }
-                  box.getOutputsByAddress(address1T.get, Paging(0, Int.MaxValue)).unsafeRunSync().total should be(3)
+                  box.getOutputsByAddress(address1T.get, Paging(0, Int.MaxValue), Sorting.Asc).unsafeRunSync().total should be(3)
                   val data = box
                     .`getUnspent&UnconfirmedOutputsMergedByAddress`(
                       address1T.get,

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/OutputQuerySet.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/queries/OutputQuerySet.scala
@@ -63,9 +63,10 @@ object OutputQuerySet extends QuerySet {
   def getMainByErgoTree(
     ergoTree: HexString,
     offset: Int,
-    limit: Int
-  )(implicit lh: LogHandler): Query0[ExtendedOutput] =
-    sql"""
+    limit: Int,
+    ordering: OrderingString
+  )(implicit lh: LogHandler): Query0[ExtendedOutput] = {
+    val q = sql"""
          |select
          |  o.box_id,
          |  o.tx_id,
@@ -85,8 +86,11 @@ object OutputQuerySet extends QuerySet {
          |from node_outputs o
          |left join node_inputs i on o.box_id = i.box_id and i.main_chain = true
          |where o.main_chain = true and o.ergo_tree = $ergoTree
-         |offset $offset limit $limit
-         |""".stripMargin.query[ExtendedOutput]
+         |""".stripMargin
+    val ord = Fragment.const(s"order by o.global_index $ordering")
+    val lim = Fragment.const(s"offset $offset limit $limit")
+    (q ++ ord ++ lim).query[ExtendedOutput]
+  }
 
   def countAllByErgoTree(
     ergoTree: HexString

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/OutputRepo.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/OutputRepo.scala
@@ -266,9 +266,10 @@ object OutputRepo {
     def streamAllByErgoTree(
       ergoTree: HexString,
       offset: Int,
-      limit: Int
+      limit: Int,
+      ordering: OrderingString
     ): Stream[D, ExtendedOutput] =
-      QS.getMainByErgoTree(ergoTree, offset, limit).stream.translate(liftK)
+      QS.getMainByErgoTree(ergoTree, offset, limit, ordering).stream.translate(liftK)
 
     def getAllMainUnspentIdsByErgoTree(ergoTree: HexString): D[List[BoxId]] =
       QS.getAllMainUnspentIdsByErgoTree(ergoTree)

--- a/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/OutputRepo.scala
+++ b/modules/explorer-core/src/main/scala/org/ergoplatform/explorer/db/repositories/OutputRepo.scala
@@ -62,7 +62,7 @@ trait OutputRepo[D[_], S[_[_], _]] {
 
   /** Get outputs with a given `ergoTree` from persistence.
     */
-  def streamAllByErgoTree(ergoTree: HexString, offset: Int, limit: Int): S[D, ExtendedOutput]
+  def streamAllByErgoTree(ergoTree: HexString, offset: Int, limit: Int, ordering: OrderingString): S[D, ExtendedOutput]
 
   /** Count outputs with a given `ergoTree` from persistence.
     */


### PR DESCRIPTION
# Expose spending proof context extension in v1 transaction inputs

Closes #264

## The problem

The v1 Explorer API does not return the spending proof context extension of transaction inputs, while the node API does (`spendingProof.extension`). Example from #264: `/api/v1/transactions/{id}` returns inputs with `spendingProof` (proof bytes) only, with no way to see the context extension variables the input was spent with.

The data is already indexed: the `node_inputs` table has an `extension JSON NOT NULL` column and the `Input` DB model carries it (`extension: Json`) — it was simply never exposed in the API model.

## The fix

`v1/models/InputInfo` now includes an `extension: Json` field (placed next to `spendingProof`, consistent with the node's `spendingProof: { proofBytes, extension }` shape), populated from `FullInput.input.extension`, with the corresponding tapir schema description. All v1 endpoints returning `InputInfo` (transactions by id, by address, etc.) now include the extension; the OpenAPI docs are derived from the schema, so they update automatically.

Non-breaking: the change only adds a field to the response payload.