### PR TITLE
Document v1 additionalRegisters as objects, not strings

### DIFF
--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/AnyOutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/AnyOutputInfo.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.explorer._
 import org.ergoplatform.explorer.db.models.AnyOutput
 import org.ergoplatform.explorer.db.models.aggregates.AnyAsset
 import org.ergoplatform.explorer.http.api.models.AssetInstanceInfo
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 @derive(encoder, decoder)
 final case class AnyOutputInfo(
@@ -48,12 +48,7 @@ object AnyOutputInfo {
 
   implicit val validator: Validator[AnyOutputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 
   def apply(
     o: AnyOutput,

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/DataInputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/DataInputInfo.scala
@@ -5,7 +5,7 @@ import io.circe.{Codec, Json}
 import org.ergoplatform.explorer._
 import org.ergoplatform.explorer.db.models.aggregates.{ExtendedAsset, FullDataInput}
 import org.ergoplatform.explorer.http.api.models.AssetInstanceInfo
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 final case class DataInputInfo(
   boxId: BoxId,
@@ -38,12 +38,7 @@ object DataInputInfo {
 
   implicit val validator: Validator[DataInputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 
   def apply(i: FullDataInput, assets: List[ExtendedAsset]): DataInputInfo =
     DataInputInfo(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/InputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/InputInfo.scala
@@ -6,7 +6,7 @@ import io.circe.Json
 import org.ergoplatform.explorer._
 import org.ergoplatform.explorer.db.models.aggregates.{ExtendedAsset, FullInput}
 import org.ergoplatform.explorer.http.api.models.AssetInstanceInfo
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 @derive(encoder, decoder)
 final case class InputInfo(
@@ -48,12 +48,7 @@ object InputInfo {
 
   implicit val validator: Validator[InputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 
   def apply(i: FullInput, assets: List[ExtendedAsset]): InputInfo = {
     val (ergoTreeConstants, ergoTreeScript) = PrettyErgoTree.fromHexString(i.ergoTree).fold(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/MOutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/MOutputInfo.scala
@@ -6,7 +6,7 @@ import derevo.derive
 import io.circe.Json
 import cats.syntax.option._
 import org.ergoplatform.explorer.{Address, BlockId, BoxId, HexString, TxId}
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 /** MOutputInfo is a merge of `UOutputInfo` & `OutputInfo`
   */
@@ -85,10 +85,5 @@ object MOutputInfo {
 
   implicit val validator: Validator[MOutputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 }

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/OutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/OutputInfo.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.explorer._
 import org.ergoplatform.explorer.db.models.Output
 import org.ergoplatform.explorer.db.models.aggregates.{ExtendedAsset, ExtendedOutput}
 import org.ergoplatform.explorer.http.api.models.AssetInstanceInfo
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 @derive(encoder, decoder)
 final case class OutputInfo(
@@ -48,12 +48,7 @@ object OutputInfo {
 
   implicit val validator: Validator[OutputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 
   def apply(
     o: ExtendedOutput,

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/RegisterInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/RegisterInfo.scala
@@ -1,0 +1,39 @@
+package org.ergoplatform.explorer.http.api.v1.models
+
+import io.circe.Json
+import sttp.tapir.{Schema, SchemaType}
+
+/**
+  * One entry of `additionalRegisters`, as the v1 API actually returns it.
+  *
+  * The field is carried as raw `io.circe.Json` in the response models, so its documented shape has
+  * to be declared by hand. It used to be declared as a plain string per register id, which is what
+  * the **v0** API returns - there `registers.convolveJson` flattens every register down to its
+  * serialized value. The v1 endpoints hand the expanded form through untouched, so the documented
+  * type did not match the response and clients generated from it were wrong.
+  *
+  * Mirrors `org.ergoplatform.explorer.protocol.models.ExpandedRegister`, which is what the raw JSON
+  * decodes to. It is kept separate rather than reused, since this type exists only to describe the
+  * response and carries no `HexString` or `SigmaType` refinement.
+  */
+final case class RegisterInfo(
+  serializedValue: String,
+  sigmaType: Option[String],
+  renderedValue: Option[String]
+)
+
+object RegisterInfo {
+
+  implicit val schema: Schema[RegisterInfo] =
+    Schema
+      .derived[RegisterInfo]
+      .modify(_.serializedValue)(_.description("Serialized value of the register"))
+      .modify(_.sigmaType)(_.description("Sigma type of the value, absent when it could not be parsed"))
+      .modify(_.renderedValue)(_.description("Rendered value of the register, absent when it could not be parsed"))
+      .description("Value of a register")
+
+  /** Schema of the `additionalRegisters` field of v1 responses: register id -> expanded register */
+  val registersSchema: Schema[Json] =
+    Schema(SchemaType.SOpenProduct[Json, RegisterInfo](schema)(_ => Map.empty))
+      .description("Registers of the box, by register id")
+}

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UDataInputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UDataInputInfo.scala
@@ -5,7 +5,7 @@ import io.circe.{Codec, Json}
 import org.ergoplatform.explorer._
 import org.ergoplatform.explorer.db.models.aggregates.{ExtendedUAsset, ExtendedUDataInput}
 import org.ergoplatform.explorer.http.api.models.AssetInstanceInfo
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 final case class UDataInputInfo(
   boxId: BoxId,
@@ -38,12 +38,7 @@ object UDataInputInfo {
 
   implicit val validator: Validator[UDataInputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 
   def apply(i: ExtendedUDataInput, assets: List[ExtendedUAsset]): UDataInputInfo =
     UDataInputInfo(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UInputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UInputInfo.scala
@@ -6,7 +6,7 @@ import io.circe.Json
 import org.ergoplatform.explorer._
 import org.ergoplatform.explorer.db.models.aggregates.{ExtendedAsset, ExtendedUAsset, ExtendedUInput}
 import org.ergoplatform.explorer.http.api.models.AssetInstanceInfo
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 @derive(encoder, decoder)
 final case class UInputInfo(
@@ -40,12 +40,7 @@ object UInputInfo {
 
   implicit val validator: Validator[UInputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 
   def apply(i: ExtendedUInput, assets: List[ExtendedUAsset], confirmedAssets: List[ExtendedAsset]): UInputInfo =
     UInputInfo(

--- a/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UOutputInfo.scala
+++ b/modules/explorer-api/src/main/scala/org/ergoplatform/explorer/http/api/v1/models/UOutputInfo.scala
@@ -7,7 +7,7 @@ import org.ergoplatform.explorer._
 import org.ergoplatform.explorer.db.models.{Output, UOutput}
 import org.ergoplatform.explorer.db.models.aggregates.{ExtendedAsset, ExtendedOutput, ExtendedUAsset, ExtendedUOutput}
 import org.ergoplatform.explorer.http.api.models.AssetInstanceInfo
-import sttp.tapir.{Schema, SchemaType, Validator}
+import sttp.tapir.{Schema, Validator}
 
 @derive(encoder, decoder)
 final case class UOutputInfo(
@@ -39,12 +39,7 @@ object UOutputInfo {
 
   implicit val validator: Validator[UOutputInfo] = schema.validator
 
-  implicit private def registersSchema: Schema[Json] =
-    Schema(
-      SchemaType.SOpenProduct(
-        Schema(SchemaType.SString[Json]())
-      )(_ => Map.empty)
-    )
+  implicit private def registersSchema: Schema[Json] = RegisterInfo.registersSchema
 
   def apply(
     o: ExtendedUOutput,

--- a/modules/explorer-api/src/test/scala/org/ergoplatform/explorer/v1/OpenApiRegistersSpec.scala
+++ b/modules/explorer-api/src/test/scala/org/ergoplatform/explorer/v1/OpenApiRegistersSpec.scala
@@ -1,0 +1,53 @@
+package org.ergoplatform.explorer.v1
+
+import org.ergoplatform.explorer.http.api.v1.defs._
+import org.ergoplatform.explorer.settings.RequestsSettings
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import sttp.tapir.docs.openapi._
+import sttp.tapir.openapi.circe.yaml._
+
+/** The v1 API returns `additionalRegisters` in the expanded form, one object per register:
+  *
+  * {{{
+  *   "additionalRegisters": {
+  *     "R4": { "serializedValue": "0e0f...", "sigmaType": "Coll[SByte]", "renderedValue": "..." }
+  *   }
+  * }}}
+  *
+  * It used to be documented as a plain string per register - which is what the **v0** API returns,
+  * since `registers.convolveJson` flattens each register there - so clients generated from the v1
+  * document did not match the responses (issue #258).
+  */
+class OpenApiRegistersSpec extends AnyFlatSpec with should.Matchers {
+
+  private val settings = RequestsSettings(100, 100, 100)
+
+  private val v1Docs: String =
+    OpenAPIDocsInterpreter()
+      .toOpenAPI(
+        new TransactionsEndpointDefs(settings).endpoints ++
+        new BoxesEndpointDefs(settings).endpoints ++
+        new MempoolEndpointDefs().endpoints,
+        "Ergo Explorer API v1",
+        "1.0"
+      )
+      .toYaml
+
+  it should "document v1 additionalRegisters as objects rather than strings" in {
+    v1Docs should include("RegisterInfo")
+    v1Docs should include("serializedValue")
+    v1Docs should include("renderedValue")
+    v1Docs should include("sigmaType")
+  }
+
+  it should "not describe a register as a bare string any more" in {
+    // the old declaration produced `additionalProperties: {type: string}` right under the field
+    val registersDeclaration = """additionalRegisters:
+                                 |          type: object
+                                 |          additionalProperties:
+                                 |            type: string""".stripMargin
+    v1Docs should not include registersDeclaration
+  }
+
+}


### PR DESCRIPTION
Closes #258.

## The mismatch

The v1 response models carry `additionalRegisters` as raw `io.circe.Json`, so its documented shape is declared by hand. All eight of them declared it as a plain string per register:

```scala
implicit private def registersSchema: Schema[Json] =
  Schema(
    SchemaType.SOpenProduct(
      Schema(SchemaType.SString[Json]())
    )(_ => Map.empty)
  )
```

That is right for **v0**, where `registers.convolveJson` flattens each register down to its serialized value before it goes out. The v1 endpoints hand the expanded form through untouched, so what actually comes back is

```json
"additionalRegisters": {
  "R4": { "serializedValue": "0e0f...", "sigmaType": "Coll[SByte]", "renderedValue": "..." }
}
```

and a client generated from the document expects a string there.

## The change

A `RegisterInfo` type describing what a register entry really looks like, and the eight v1 models pointing their register schema at it. Nothing changes at runtime - the field is still `Json`, still serialized the same way; only the generated document changes. The affected models are `OutputInfo`, `UOutputInfo`, `MOutputInfo`, `AnyOutputInfo`, `InputInfo`, `UInputInfo`, `DataInputInfo` and `UDataInputInfo`.

v0 is deliberately left alone: its string declaration matches its responses.

Generated v1 document, after:

```yaml
additionalRegisters:
  type: object
  description: Registers of the box, by register id
  additionalProperties:
    $ref: '#/components/schemas/RegisterInfo'
```

## Test

`OpenApiRegistersSpec` builds the v1 OpenAPI document the same way `DocsRoutes` does and asserts the registers are described as objects with `serializedValue`, `sigmaType` and `renderedValue`, and no longer as a bare string. I checked it fails on the current code before the fix and passes after it, so it is a real guard rather than a tautology.

Built and tested on JDK 11 (sbt 1.5.5 does not run on newer JDKs).